### PR TITLE
Publish jars with maven poms

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -16,7 +16,7 @@ VERSION=`curl -s -I https://github.com/ContainerSolutions/mini-mesos/releases/la
 
 mkdir -p /usr/local/share/minimesos
 
-curl -sSL https://jitpack.io/com/github/ContainerSolutions/mini-mesos/$VERSION/mini-mesos-$VERSION.jar > /usr/local/share/minimesos/mini-mesos-$VERSION.jar
+curl -sSL https://jitpack.io/com/github/ContainerSolutions/mini-mesos/$VERSION/mini-mesos-$VERSION-all.jar > /usr/local/share/minimesos/mini-mesos-$VERSION.jar
 curl -sSL https://raw.githubusercontent.com/ContainerSolutions/mini-mesos/$VERSION/bin/minimesos > /usr/local/bin/minimesos
 
 chmod +x /usr/local/bin/minimesos

--- a/build.gradle
+++ b/build.gradle
@@ -158,3 +158,4 @@ afterEvaluate { project ->
 }
 
 assemble.dependsOn copyExecutableJar
+install.dependsOn copyExecutableJar

--- a/build.gradle
+++ b/build.gradle
@@ -75,7 +75,6 @@ mainClassName = "com.containersol.minimesos.main.Main"
 
 jar {
     baseName = "minimesos"
-    from { configurations.compile.collect { it.isDirectory() ? it : zipTree(it) } }
     manifest {
         attributes(
                 'Main-Class'                : mainClassName,
@@ -85,12 +84,26 @@ jar {
     exclude 'META-INF/*.RSA', 'META-INF/*.SF','META-INF/*.DSA'
 }
 
-task copyJar(type: Copy) {
-    dependsOn 'jar'
-    rename { String fileName ->
-        fileName.replace("-${project.version}", "")
+task executableJar(type: Jar) {
+    baseName = "minimesos"
+    classifier = "all"
+    from { configurations.compile.collect { it.isDirectory() ? it : zipTree(it) } }
+    with jar
+    manifest {
+        attributes(
+                'Main-Class'                : mainClassName,
+                'Implementation-Version'    : project.version
+        )
     }
-    from        "build/libs/minimesos-${project.version}.jar"
+    exclude 'META-INF/*.RSA', 'META-INF/*.SF','META-INF/*.DSA'
+}
+
+task copyExecutableJar(type: Copy) {
+    dependsOn 'executableJar'
+    rename { String fileName ->
+        fileName.replace("-${project.version}-all", "")
+    }
+    from        "build/libs/minimesos-${project.version}-all.jar"
     into        'build/libs'
 }
 
@@ -144,4 +157,4 @@ afterEvaluate { project ->
     }
 }
 
-build.dependsOn copyJar
+assemble.dependsOn copyExecutableJar

--- a/build.gradle
+++ b/build.gradle
@@ -107,6 +107,10 @@ task copyExecutableJar(type: Copy) {
     into        'build/libs'
 }
 
+artifacts {
+    archives executableJar
+}
+
 afterEvaluate { project ->
     if (new File(project.projectDir, 'Dockerfile').exists()) {
         if (!project.hasProperty('imageName')) {


### PR DESCRIPTION
Currently the Gradle is publishing fat-jars with all dependencies inside, see attachment.

![pasted image at 2015_10_12 09_48 am](https://cloud.githubusercontent.com/assets/81906/10424762/d6e88274-70c9-11e5-93fe-e6bca55243f2.png)

Skinny jars with maven pom.xml files is much preferred.